### PR TITLE
Converting strings to values using culture invariant conventions

### DIFF
--- a/Stuff.cs
+++ b/Stuff.cs
@@ -48,6 +48,6 @@ static class Stuff
 	{
 		string s = ((XmlElement)node).GetAttribute(attribute);
 		var converter = TypeDescriptor.GetConverter(typeof(T));
-		return s == "" ? defaultT : (T)converter.ConvertFromString(s);
+		return s == "" ? defaultT : (T)converter.ConvertFromInvariantString(s);
 	}
 }


### PR DESCRIPTION
ConvertFromString fails when trying to parse floating numeric values in systems where the expected decimal separator is not the same than in the author's expected one.

In our case, weights are formatted with dot as decimal separator as in:
`<tile name="grasscorner" symmetry="L" weight="0.0001"/>`

In my system, the decimal separator is ',' (ES_ES) so 0.0001 is not a valid format 

In order to avoid this kind of issues it's a common practice to use the ConvertFromInvariantString method instead. This way you bypass the system Culture