### PR TITLE
3x speedup: Hoist "allowed" check in OverlappingModel#propagate

### DIFF
--- a/OverlappingModel.cs
+++ b/OverlappingModel.cs
@@ -197,11 +197,12 @@ class OverlappingModel : Model
 
 							for (int t2 = 0; t2 < T; t2++)
 							{
+								if (!allowed[t2]) continue;
 								b = false;
 								int[] prop = propagator[t2][N - 1 - dx][N - 1 - dy];
 								for (int i1 = 0; i1 < prop.Length && !b; i1++) b = wave[x1][y1][prop[i1]];
 
-								if (allowed[t2] && !b)
+								if (!b)
 								{
 									changes[sx][sy] = true;
 									change = true;


### PR DESCRIPTION
The "allowed" check in the innermost-loop of OverlappingModel#propagate can be safely hoisted to the top of the loop and doing so provides a massive speedup.

---
Performance numbers:
(I added some basic instrumentation with Stopwatch)

## City

`<overlapping name="City" N="3" symmetry="2" foundation="-1" periodic="True"/>`

Before:
```
< City
> DONE in 10.6412399s
> DONE in 10.2346078s
```

After:
```
< City
> DONE in 3.4074682s
> DONE in 3.2315486s
```

Roughly 3x speedup.

## All + Platformer + 3Bricks

Before:
```
TOTAL TIME (all `<overlapping>`): 298.2288456s

< Platformer (N=3)
> DONE in 3.6201797s
> DONE in 6.1962286s

< 3Bricks
> CONTRADICTION
> DONE in 73.8861201s
> DONE in 75.184608s
```

After:
```
TOTAL TIME (all `<overlapping>`): 183.6418427s

< Platformer (N=3)
> DONE in 2.1512673s
> DONE in 1.8658939s

< 3Bricks
> CONTRADICTION
> CONTRADICTION
> DONE in 19.6964029s
> CONTRADICTION
> CONTRADICTION
> CONTRADICTION
> DONE in 16.5563298s
```

Of course the total times vary wildly depending on...well, how many contradictions 3Bricks runs into, really.

### Second run

More favorable, so...why not include.

```
TOTAL TIME (all `<overlapping>`): 108.0454612s

< Platformer (N=3)
> DONE in 3.0047066s
> DONE in 2.3627346s

< 3Bricks
> DONE in 21.5364856s
> DONE in 18.892922s
```