### PR TITLE
Fix algorithm ordering in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ Watch a video demonstration of WFC algorithm on YouTube: [https://youtu.be/DOQTr
 
 ## Algorithm
 1. Read the input bitmap and count NxN patterns.
-  1. (optional) Augment pattern data with rotations and reflections.
+    1. (optional) Augment pattern data with rotations and reflections.
 2. Create an array with the dimensions of the output (called "wave" in the source). Each element of this array represents a state of an NxN region in the output. A state of an NxN region is a superpostion of NxN patterns of the input with boolean coefficients (so a state of a pixel in the output is a superposition of input colors with real coefficients). False coefficient means that the corresponding pattern is forbidden, true coefficient means that the corresponding pattern is not yet forbidden.
 3. Initialize the wave in the completely unobserved state, i.e. with all the boolean coefficients being true.
 4. Repeat the following steps:
-  1. Observation:
-    1. Find a wave element with the minimal nonzero entropy. If there is no such elements (if all elements have zero or undefined entropy) then break the cycle (4) and go to step (5).
-    2. Collapse this element into a definite state according to its coefficients and the distribution of NxN patterns in the input.
-  2. Propagation: propagate information gained on the previous observation step.
+    1. Observation:
+        1. Find a wave element with the minimal nonzero entropy. If there is no such elements (if all elements have zero or undefined entropy) then break the cycle (4) and go to step (5).
+        2. Collapse this element into a definite state according to its coefficients and the distribution of NxN patterns in the input.
+    2. Propagation: propagate information gained on the previous observation step.
 5. By now all the wave elements are either in a completely observed state (all the coefficients except one being zero) or in the contradictive state (all the coefficients being zero). In the first case return the output. In the second case finish the work without returning anything.
 
 ## Tilemap generation


### PR DESCRIPTION
The ordered list used for the algorithm section renders differently than you wanted (based on the raw markdown).
This minor indentation fix will do something more like you expected in GitHub.