### PR TITLE
Create runtimeconfig.template.json

### DIFF
--- a/runtimeconfig.template.json
+++ b/runtimeconfig.template.json
@@ -1,0 +1,5 @@
+{
+  "configProperties": {
+    "System.Drawing.EnableUnixSupport": true
+  }
+}


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/system-drawing-common-windows-only

On newer .NET releases, this no longer runs by default on non-Windows systems. Adding this config template allows System.Drawing.Common to be re-implemented in the build output so it can run on other platforms. Example stacktrace:

```
Unhandled exception. System.TypeInitializationException: The type initializer for 'Gdip' threw an exception.
 ---> System.PlatformNotSupportedException: System.Drawing.Common is not supported on non-Windows platforms. See https://aka.ms/systemdrawingnonwindows for more information.
   at System.Drawing.LibraryResolver.EnsureRegistered()
   at System.Drawing.SafeNativeMethods.Gdip.PlatformInitialize()
   at System.Drawing.SafeNativeMethods.Gdip..cctor()
   --- End of inner exception stack trace ---
   at System.Drawing.SafeNativeMethods.Gdip.GdipCreateBitmapFromFile(String filename, IntPtr& bitmap)
   at System.Drawing.Bitmap..ctor(String filename, Boolean useIcm)
   at System.Drawing.Bitmap..ctor(String filename)
```